### PR TITLE
fix `implied_bounds_entailment` lint

### DIFF
--- a/src/ral.rs
+++ b/src/ral.rs
@@ -27,7 +27,7 @@ use ral_registers::{RORegister, RWRegister, WORegister};
 pub(super) struct Static<T>(pub(super) *const T);
 impl<T> core::ops::Deref for Static<T> {
     type Target = T;
-    fn deref(&self) -> &'static Self::Target {
+    fn deref(&self) -> &Self::Target {
         // Safety: pointer points to static memory (peripheral memory)
         unsafe { &*self.0 }
     }


### PR DESCRIPTION
Hey :wave: this crate unintentionally relied on a soundness bug in the Rust compiler, see https://github.com/rust-lang/rust/issues/105572 for more info. This lint will be a hard error in a future release and is fixed by this PR.

The issue was that inside of `deref`, we assume that `Self::Target` has to life to `'static` even though that's never proven by the caller of `deref` because `deref` returns `&'static Self::Target`. Users of `Deref` for `Static<T>` always only used the signature of the trait method, so the stronger bound on the impl did not impact them.